### PR TITLE
Use different Roblox API for real-time game information

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,6 @@ const axios = require('axios');
 const fs = require('fs');
 
 const inputGames = require('./input_games.json');
-const { start } = require('repl');
 
 // we need to also use .get on each takes owner, and repo
 
@@ -12,133 +11,129 @@ const lastWeekTimestamp = new Date(pastTimestamp);
 
 console.log(currentDate.toDateString(), lastWeekTimestamp.toDateString());
 
-const promises = [];
-let gameStats = {};
+const gameStats = {};
 let weeklyPlaytime = 0;
 let weeklyVisits = 0;
 let totalVisits = 0;
 let totalFavorites = 0;
 let totalCCU = 0;
-for (let gameName in inputGames) {
-	const assetId = inputGames[gameName];
 
-	console.log(`Retrieving info for ${gameName} with ID of: ${assetId}`);
+const main = async() => {
+	const universeIds = []
+	// We could do this asyncronously with Promise.all, but let's not abuse the roblox APIs any more than we have to
+	for (assetId of Object.values(inputGames)) {
+		const response = await axios.get(`https://apis.roblox.com/universes/v1/places/${assetId}/universe`);
+		universeIds.push(response.data.universeId);
+	}
+	const gameDataResponse = await axios.get(`https://games.roblox.com/v1/games?universeIds=${universeIds.join(",")}`);
 
-	const promise = axios
-		.get(`https://www.roblox.com/places/api-get-details?assetId=${assetId}`)
-		.then((response) => {
-			const data = response.data;
+	// Restructure the data keyed by place ID (we don't have access to gameName here)
+	const gameInfo = {};
+	for (const game of gameDataResponse.data.data) {
+		gameInfo[game.rootPlaceId] = {
+			universeId: game.id,
 
-			const likes = data['TotalUpVotes'];
-			const dislikes = data['TotalDownVotes'];
+			visits: game.visits,
+			favourites: game.favoritedCount,
+			ccu: game.playing,
+		}
 
-			const likeRatio = Math.round((likes / (likes + dislikes)) * 100);
+		totalVisits += game.visits;
+		totalFavorites += game.favoritedCount;
+		totalCCU += game.playing;
+	}
 
-			totalVisits += data['VisitedCount'];
-			totalFavorites += data['FavoritedCount'];
-			totalCCU += data['OnlineCount']
+	for (const gameName in inputGames) {
+		const assetId = inputGames[gameName];
 
-			gameStats[gameName] = {
-				CCU: data['OnlineCount'],
-				Visits: data['VisitedCount'],
-				Ratio: likeRatio,
-			};
-		})
-		.catch((error) => {
-			console.error(`Error retrieving info for ${gameName}:`, error);
-		});
+		gameStats[gameName] = {
+			CCU: gameInfo[assetId].ccu,
+			Visits: gameInfo[assetId].visits,
+			Ratio: -1,  // Populated below
+		};
 
-	const lastWeekTimestampMonth = lastWeekTimestamp.getMonth() + 1;
-	const currentWeekMonth = currentDate.getMonth() + 1; // 0 indexing D:
+		// There's no API for this, but we do have an endpoint that gives us HTML
+		const votesResponse = await axios.get(`https://www.roblox.com/games/votingservice/${assetId}`)
+		const likes = parseInt(/id="vote-up-text" title="(\d+)"/.exec(votesResponse.data)[1]);
+		const dislikes = parseInt(/id="vote-down-text" title="(\d+)"/.exec(votesResponse.data)[1]);
+		const likeRatio = Math.round((likes / (likes + dislikes)) * 100);
+		gameStats[gameName].Ratio = likeRatio;
 
-	const startRange = `${lastWeekTimestamp.getFullYear()}-${
-		(lastWeekTimestampMonth < 10 ? '0' : '') + lastWeekTimestampMonth
-	}-${
-		(lastWeekTimestamp.getDate() < 10 ? '0' : '') + lastWeekTimestamp.getDate()
-	}`;
-	const endRange = `${currentDate.getFullYear()}-${
-		(currentWeekMonth < 10 ? '0' : '') + currentWeekMonth
-	}-${(currentDate.getDate() < 10 ? '0' : '') + currentDate.getDate()}`;
+		// Build ranges for romonitorstats
+		const startRange = `${
+			lastWeekTimestamp.getFullYear()
+		}-${
+			(lastWeekTimestamp.getMonth() + 1).toString().padStart(2, "0")
+		}-${
+			lastWeekTimestamp.getDate().toString().padStart(2, "0")
+		}`;
+		const endRange = `${currentDate.getFullYear()}-${
+			(currentDate.getMonth() + 1).toString().padStart(2, "0")
+		}-${
+			currentDate.getDate().toString().padStart(2, "0")
+		}`;
 
-	promises.push(
-		axios
-			.get(
-				`https://romonitorstats.com/api/v1/charts/get?name=session-length&placeId=${assetId}&timeslice=day&proVersion=false&includeExperienceName=true&start=${startRange}&ends=${endRange}`
-			)
-			.then((response) => {
-				const sessionData = response.data[0].data;
-
-				for (let date in sessionData) {
-					const time = sessionData[date];
-					weeklyPlaytime += time;
-				}
-			})
-	);
-
-	promises.push(
-		axios
-			.get(
-				`https://romonitorstats.com/api/v1/charts/get?name=visits&placeId=${assetId}&timeslice=day&proVersion=false&includeExperienceName=true&start=${startRange}&ends=${endRange}`
-			)
-			.then((response) => {
-				const sessionData = response.data[0].data;
-
-				for (let date in sessionData) {
-					const visits = sessionData[date];
-					weeklyVisits += visits;
-				}
-			})
-	);
-
-	promises.push(promise);
-}
-
-Promise.all(promises)
-	.then(() => {
-		console.log(gameStats);
-		weeklyVisits = weeklyVisits / 7;
-		weeklyPlaytime = weeklyPlaytime / 7;
-
-		let monthlyAverageHours = Math.round(
-			(weeklyPlaytime * weeklyVisits * 30) / 60
+		// Request historical data from romonitorstats (no official APIs for this)
+		const playtimeResponse = await axios.get(
+			`https://romonitorstats.com/api/v1/charts/get?name=session-length&placeId=${assetId}&timeslice=day&proVersion=false&includeExperienceName=true&start=${startRange}&ends=${endRange}`
 		);
+		for (const time of Object.values(playtimeResponse.data[0].data)) {
+			weeklyPlaytime += time;
+		}
 
-		console.log(`Monthly average playtime (HOURS): ${monthlyAverageHours}`);
-		console.log(`Total Favorites: ${totalFavorites}`);
-		console.log(`Total Visits: ${totalVisits}`);
+		const visitsResponse = await axios.get(
+			`https://romonitorstats.com/api/v1/charts/get?name=visits&placeId=${assetId}&timeslice=day&proVersion=false&includeExperienceName=true&start=${startRange}&ends=${endRange}`
+		);
+		for (const visits of Object.values(visitsResponse.data[0].data)) {
+			weeklyVisits += visits;
+		}
+	}
 
-		const jsonString = JSON.stringify(gameStats, null, 2); // Pretty print with 2-space indentation
+	console.log(gameStats);
+	weeklyVisits = weeklyVisits / 7;
+	weeklyPlaytime = weeklyPlaytime / 7;
 
-		// Write the JSON string to a file
-		fs.writeFile('gameStats.json', jsonString, (err) => {
+	const monthlyAverageHours = Math.round(
+		(weeklyPlaytime * weeklyVisits * 30) / 60
+	);
+
+	console.log(`Monthly average playtime (HOURS): ${monthlyAverageHours}`);
+	console.log(`Total Favorites: ${totalFavorites}`);
+	console.log(`Total Visits: ${totalVisits}`);
+
+	const jsonString = JSON.stringify(gameStats, null, 2); // Pretty print with 2-space indentation
+
+	// Write the JSON string to a file
+	fs.writeFile('gameStats.json', jsonString, (err) => {
+		if (err) {
+			console.error('Error writing to file', err);
+		} else {
+			console.log('Successfully wrote gameStats to gameStats.json');
+		}
+	});
+
+	fs.writeFile(
+		'globalStats.json',
+		JSON.stringify(
+			{
+				TotalVisits: totalVisits,
+				TotalCCU: totalCCU,
+				TotalFavorites: totalFavorites,
+				MonthlyAverageHours: monthlyAverageHours,
+			},
+			null,
+			2
+		),
+		(err) => {
 			if (err) {
 				console.error('Error writing to file', err);
 			} else {
-				console.log('Successfully wrote gameStats to gameStats.json');
+				console.log('Successfully wrote globalStats to globalStats.json');
 			}
-		});
+		}
+	);
+}
 
-		fs.writeFile(
-			'globalStats.json',
-			JSON.stringify(
-				{
-					TotalVisits: totalVisits,
-					TotalCCU: totalCCU,
-					TotalFavorites: totalFavorites,
-					MonthlyAverageHours: monthlyAverageHours,
-				},
-				null,
-				2
-			),
-			(err) => {
-				if (err) {
-					console.error('Error writing to file', err);
-				} else {
-					console.log('Successfully wrote globalStats to globalStats.json');
-				}
-			}
-		);
-	})
-	.catch((error) => {
-		console.error('Error in Promise.all:', error);
-	});
+main().catch((error) => {
+	console.error('Error generating data:', error);
+});


### PR DESCRIPTION
`/places/api-get-details` doesn't work anymore, but the Legacy endpoint `/v1/games` does (and is also what the Roblox website is currently using).

While I was at it I ended up flattening quite a few promises into `await`s mostly because it simplified the required merging and unmerging of data to perform a bulk game lookup request. This has the side effect of making the script run a bit slower (requests are no longer parallel) with the up-side of no longer hammering the APIs being used 😝.

The indentation level changing made the git diff quite horrific but it's not nearly as many changes as this would suggest.